### PR TITLE
rfc: Claude Code A2A integration exploration

### DIFF
--- a/tasks/001-claude-code-ark-integration/00-plan.md
+++ b/tasks/001-claude-code-ark-integration/00-plan.md
@@ -1,0 +1,55 @@
+---
+owner: ark-protocol-orchestrator
+description: Integrate Claude Code with Ark via A2A protocol
+---
+
+# Claude Code Ark Integration - Plan
+
+## Focus
+
+Testing Claude Code A2A agents specifically via Ark's existing A2A support.
+
+## Key Finding
+
+**Ark already has native A2A support.** Zero code changes required.
+
+A2A was chosen as the path of least resistance. Other methods exist (custom execution engine, direct integration) but A2A requires no Ark modifications.
+
+## Tasks
+
+- [x] Define objectives
+- [x] Define acceptance criteria
+- [x] Design architecture
+- [x] Define verifiable prototype steps
+- [ ] Execute prototype
+- [ ] Document verification evidence
+- [ ] Document outcome
+
+## Prototype Steps
+
+Sequential verification in `04-verifiable-prototype.md`:
+
+1. **Hello World** - Install chart, query agent
+2. **OTEL** - Verify telemetry flows to backend
+3. **MCP** - Configure MCP servers via chart
+4. **Skills** - Configure Claude skills/agents via chart
+
+## Resources
+
+Installation resources in `99-resources/`:
+- `step1-install.sh` - Basic helm install
+- `otel-configmap.yaml` - OTEL configuration
+- `mcp-config.yaml` - MCP server configuration
+- `skills-config.yaml` - Skills configuration
+
+## Findings
+
+Discoveries tracked in `99-findings/`:
+- `01-visibility-enhancements.md` - Options for improving observability
+- `02-otel-auto-injection.md` - Chart change for OTEL auto-injection
+
+## Next Steps
+
+1. Execute prototype steps sequentially
+2. Collect verification evidence per step
+3. Document outcome and learnings

--- a/tasks/001-claude-code-ark-integration/01-objectives.md
+++ b/tasks/001-claude-code-ark-integration/01-objectives.md
@@ -1,0 +1,68 @@
+# Task: claude-code-ark-integration
+
+Initial request: "Orchestrate an exploration of how to integrate Claude Code with Ark for AI agent orchestration."
+
+## Status
+Phase: Prototype Execution
+
+## Plan
+- [x] 01-objectives - Define why and goals
+- [x] 02-acceptance-criteria - Define "done" + verification methods
+- [x] 03-architecture - Design solution
+- [ ] 04-verifiable-prototype - Build with checkpoints
+- [ ] 05-verification - Prove each criterion with evidence
+- [ ] 06-outcome - Document learnings
+
+## Initial Analysis
+
+**A2A is the path of least resistance.** After analyzing Ark's architecture, A2A protocol integration requires zero core changes to Ark.
+
+Alternative approaches exist (custom execution engine, direct integration) but A2A offers:
+- No Ark code changes required
+- Leverages existing A2AServer controller
+- Standard protocol with auto-discovery
+- Clean separation of concerns
+
+We are focusing exclusively on A2A integration for this prototype.
+
+## Why This Task Matters
+
+Claude Code offers unique capabilities: deep codebase understanding, sophisticated file operations, git workflows, and Claude's advanced reasoning. Integrating via A2A enables Ark users to leverage these through the standard Ark API.
+
+## Key Finding: Ark Already Has A2A Support
+
+**Ark has native A2A (Agent-to-Agent) protocol support built in.** Zero code changes required.
+
+### How It Works
+
+1. **A2AServer CRD** - Ark has a custom resource for A2A servers
+2. **Auto-discovery** - A2AServerReconciler discovers agents from `/.well-known/agent-card.json`
+3. **Agent creation** - Automatically creates Agent CRDs with `executionEngine: a2a`
+4. **OTEL injection** - Ark injects OTEL trace headers into A2A requests
+
+## Goals
+
+### Primary Goals
+
+1. **Zero-Code Integration**: Use Ark's existing A2A support to orchestrate Claude Code agents
+2. **Minimal Deployment**: Helm install claude-code-agent + A2AServer auto-creation
+3. **Observability**: Route Claude Code OTEL telemetry to configured backend
+
+### Secondary Goals
+
+4. **MCP Configuration**: Enable MCP servers via Helm values
+5. **Skills Configuration**: Enable Claude skills/agents via Helm values
+
+### Non-Goals
+
+- Modifying Ark's native Go loop
+- Building new execution engines
+- Implementing new A2A protocol features
+
+## Key Code Locations
+
+| Component | File |
+|-----------|------|
+| A2A execution engine | `ark/internal/genai/a2a_execution.go` |
+| A2AServer controller | `ark/internal/controller/a2aserver_controller.go` |
+| A2AServer CRD | `ark/api/v1prealpha1/a2aserver_types.go` |

--- a/tasks/001-claude-code-ark-integration/02-acceptance-criteria.md
+++ b/tasks/001-claude-code-ark-integration/02-acceptance-criteria.md
@@ -1,0 +1,65 @@
+# Acceptance Criteria
+
+## Trust
+
+How can we build trust in this process and these learnings?
+
+- Acceptance criteria with verification method for each
+- Working prototype demonstrates end-to-end flow
+- Architecture decisions documented with rationale
+
+## Research Available
+
+| Question | Answer | Artifact |
+|----------|--------|----------|
+| How does claude-code-agent implement A2A? | Express server with JSON-RPC, spawns Claude CLI | `99-research/claude-code-agent.md` |
+| Can Claude Code send OTEL to Ark Broker? | Yes, via OTEL env vars to Broker's /v1/traces | `99-research/ark-broker-otel.md` |
+| How are MCP servers configured? | Via `--mcp-config` flag or mounted config | `99-research/claude-code-agent.md` |
+
+## Criteria
+
+### Integration Architecture
+
+| Criterion | Verification Method |
+|-----------|---------------------|
+| Claude Code agent can be deployed to Ark cluster | `helm install` succeeds, pod runs |
+| A2A protocol allows message exchange with Claude Code | `curl` to A2A endpoint returns response |
+| Session continuity works for multi-turn conversations | Send multiple messages, verify context maintained |
+
+### Observability
+
+| Criterion | Verification Method |
+|-----------|---------------------|
+| Claude Code OTEL spans reach Ark Broker | Query `/traces` API shows Claude spans |
+| Spans include useful agent context (tool calls, etc.) | Inspect span attributes in broker response |
+
+### Customization
+
+| Criterion | Verification Method |
+|-----------|---------------------|
+| MCP servers can be configured via Helm values | Deploy with MCP config, verify server loads |
+| Skills can be mounted into agent container | Deploy with skill, invoke skill via message |
+| Multiple agent configurations can coexist | Deploy two agents with different configs, both work |
+
+### Documentation
+
+| Criterion | Verification Method |
+|-----------|---------------------|
+| Architecture diagram shows integration points | Visual review of diagram |
+| Deployment steps documented | Follow steps, achieve working setup |
+| Customization patterns documented | Follow patterns, achieve custom config |
+
+## Out of Scope (Follow-on Tasks)
+
+- Production security review and hardening
+- Performance benchmarking and optimization
+- Integration with Ark Dashboard UI
+- Automated agent registration with Ark controller
+
+## Definition of Done
+
+1. Architecture document explains integration approach
+2. Prototype demonstrates Claude Code responding via A2A
+3. OTEL spans visible in Ark Broker
+4. Documentation covers deployment and customization
+5. All acceptance criteria verified with evidence

--- a/tasks/001-claude-code-ark-integration/03-architecture.md
+++ b/tasks/001-claude-code-ark-integration/03-architecture.md
@@ -1,0 +1,153 @@
+# Architecture: Claude Code + Ark Integration
+
+## Summary
+
+**Ark already has native A2A support.** The integration requires zero code changes to Ark.
+
+## Ark's Agentic Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           QUERY CONTROLLER                               │
+│  (Kubernetes reconciliation loop for Query CRDs)                        │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │     Target Type Router        │
+                    │  (agent/team/model/tool)      │
+                    └───────────────────────────────┘
+                                    │
+                    ┌───────────────┴───────────────┐
+                    ▼                               ▼
+        ┌───────────────────┐           ┌───────────────────┐
+        │  Native Go Loop   │           │  Execution Engine │
+        │  (executeLocally) │           │  (if specified)   │
+        └───────────────────┘           └───────────────────┘
+                │                               │
+                │                     ┌─────────┴─────────┐
+                │                     ▼                   ▼
+                │             ┌─────────────┐     ┌─────────────┐
+                │             │  A2A Engine │     │ HTTP Engine │
+                │             │  (reserved) │     │ (langchain) │
+                │             └─────────────┘     └─────────────┘
+                │                     │
+                ▼                     ▼
+        ┌───────────────┐     ┌───────────────────────┐
+        │ Multi-turn    │     │ External A2A Server   │
+        │ tool-calling  │     │ (claude-code-agent)   │
+        │ loop          │     └───────────────────────┘
+        └───────────────┘
+```
+
+### Key Architecture Points
+
+1. **Native Go Implementation** (`ark/internal/genai/agent.go:executeLocally`)
+   - Default execution path for agents
+   - Multi-turn tool-calling loop built into the controller
+   - Supports all tool types: HTTP, MCP, Agent, Team, Builtin
+
+2. **Execution Engine Pattern** (`agent.go:66-88`)
+   - Optional override when `.spec.executionEngine` is set
+   - Routes to external systems (LangChain, A2A, etc.)
+   - **`a2a` is a reserved execution engine name**
+
+3. **A2A Execution Engine** (`ark/internal/genai/a2a_execution.go`)
+   - Handles `executionEngine: a2a` agents
+   - Communicates via Google's A2A JSON-RPC protocol
+   - Injects OTEL trace headers for observability
+
+## A2A Integration Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 1. Deploy claude-code-agent (Helm or DevSpace)                         │
+│    └── Runs A2A server at http://claude-code-agent:2222                │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 2. Create A2AServer CRD                                                 │
+│    apiVersion: ark.mckinsey.com/v1prealpha1                            │
+│    kind: A2AServer                                                      │
+│    spec:                                                                │
+│      address:                                                           │
+│        value: "http://claude-code-agent:2222"                          │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 3. A2AServerReconciler auto-discovers agent                            │
+│    └── GET /.well-known/agent-card.json                                │
+│    └── Creates Agent CRD with executionEngine: a2a                     │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 4. User queries agent via Ark API/Dashboard                            │
+│    POST /api/v1/query { target: "agent/claude-code", message: "..." }  │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 5. Query Controller routes to A2AExecutionEngine                       │
+│    └── Sends JSON-RPC message/stream to claude-code-agent              │
+│    └── Injects OTEL headers (traceparent, tracestate)                  │
+│    └── Returns response to user                                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Observability Path
+
+```
+┌─────────────┐     OTEL Headers      ┌─────────────────────┐
+│ Ark Query   │ ──────────────────►   │ claude-code-agent   │
+│ Controller  │                       │                     │
+└─────────────┘                       └─────────────────────┘
+      │                                        │
+      │ traces                                 │ traces (if enabled)
+      ▼                                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     Ark Broker                               │
+│                  (/v1/traces endpoint)                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Ark injects OTEL headers via `telemetry.InjectOTELHeaders()` in `a2a.go:188-192`.
+claude-code-agent can export traces to the same endpoint with:
+```yaml
+env:
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://ark-broker:3000"
+```
+
+## Multi-Agent / Customization
+
+Multiple claude-code-agent instances with different configs:
+
+```yaml
+# Research agent with research tools
+helm install claude-code-research oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --set agentName=claude-research \
+  --set-file mcpConfig=research-mcp.json \
+  --set-file skills=research-skills/
+
+# Coding agent with coding tools
+helm install claude-code-coding oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --set agentName=claude-coding \
+  --set-file mcpConfig=coding-mcp.json \
+  --set-file skills=coding-skills/
+```
+
+Each creates a separate A2AServer → separate Agent in Ark.
+
+## Key Code Locations
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| A2A reserved engine | `ark/internal/genai/a2a_types.go:10` | `ExecutionEngineA2A = "a2a"` |
+| A2A routing | `ark/internal/genai/agent.go:79` | Routes to A2A when engine is "a2a" |
+| A2A execution | `ark/internal/genai/a2a_execution.go` | Sends JSON-RPC to A2A server |
+| A2A protocol | `ark/internal/genai/a2a.go` | A2A client, discovery, OTEL injection |
+| A2AServer controller | `ark/internal/controller/a2aserver_controller.go` | Auto-discovers and creates Agents |
+| A2AServer CRD | `ark/api/v1prealpha1/a2aserver_types.go` | A2AServer spec definition |

--- a/tasks/001-claude-code-ark-integration/04-verifiable-prototype.md
+++ b/tasks/001-claude-code-ark-integration/04-verifiable-prototype.md
@@ -1,0 +1,167 @@
+# Verifiable Prototype
+
+Sequential verification steps for Claude Code A2A integration with Ark.
+
+## Prerequisites
+
+- Ark installed in cluster
+- `ANTHROPIC_API_KEY` environment variable set
+- `ark` or `fark` CLI available
+
+## Step 1: Hello World
+
+**Goal**: Deploy claude-code-agent and verify basic query execution.
+
+```bash
+# Install the chart with Anthropic key (requires v0.1.3+ for envFrom support)
+helm install claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY
+
+# Verify A2AServer and Agent created. Might take a couple of mins.
+kubectl get a2aserver
+kubectl get agent
+
+# Query the agent
+ark query agent/claude-code "What is 2 + 2?"
+```
+
+**Checkpoint 1:**
+- [x] Helm install succeeds
+- [x] A2AServer shows Ready
+- [x] Agent CRD auto-created
+- FAIL: Query returns correct response
+
+Note: the failure is related to A2A message response accumulation. See [PR #579](https://github.com/mckinsey/agents-at-scale-ark/pull/579) for the fix.
+
+## Step 2: OTEL Telemetry
+
+**Goal**: Verify telemetry flows to configured backend.
+
+Ark uses `otel-environment-variables` ConfigMap/Secret for OTEL configuration. Create it if not present:
+
+```bash
+# Check existing OTEL config
+kubectl get configmap otel-environment-variables 2>/dev/null || echo "No OTEL ConfigMap"
+
+# If needed, create OTEL config (example for Phoenix)
+kubectl apply -f 99-resources/otel-configmap.yaml
+
+# Upgrade chart to pick up OTEL config (requires envFrom in chart)
+helm upgrade claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY
+
+# Restart pod to pick up new env
+kubectl rollout restart deployment/claude-code-agent
+
+# Send a query to generate traces
+ark query agent/claude-code-agent "Tell me about observability"
+
+# Check agent logs for OTEL activity
+kubectl logs -l app.kubernetes.io/name=claude-code-agent | grep -i otel
+```
+
+**Checkpoint 2:**
+- [ ] OTEL ConfigMap/Secret exists in namespace
+- [ ] Agent picks up OTEL environment variables
+- [ ] Traces visible in backend (Phoenix/Langfuse/etc.)
+- [ ] Spans include Claude model calls
+
+## Step 3: MCP Servers
+
+**Goal**: Configure MCP servers via Helm chart.
+
+```bash
+# Create MCP config
+kubectl apply -f 99-resources/mcp-config.yaml
+
+# Upgrade chart with MCP config reference
+helm upgrade claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY \
+  --set mcpConfig.existingSecret=mcp-config
+
+# Restart pod
+kubectl rollout restart deployment/claude-code-agent
+
+# Verify MCP server loaded (check agent logs)
+kubectl logs -l app.kubernetes.io/name=claude-code-agent | grep -i mcp
+
+# Test MCP tool usage
+ark query agent/claude-code-agent "Use the filesystem tool to list /tmp"
+```
+
+**Checkpoint 3:**
+- [ ] MCP config mounted into container
+- [ ] MCP server appears in agent logs at startup
+- [ ] Agent can use MCP tools in queries
+
+## Step 4: Skills Configuration
+
+**Goal**: Configure Claude skills/agents via Helm chart.
+
+```bash
+# Create skills ConfigMap
+kubectl apply -f 99-resources/skills-config.yaml
+
+# Upgrade chart with skills mount
+helm upgrade claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY \
+  --set skills.existingConfigMap=skills-config
+
+# Restart pod
+kubectl rollout restart deployment/claude-code-agent
+
+# Test skill invocation
+ark query agent/claude-code-agent "Use the greeting skill to say hello"
+```
+
+**Checkpoint 4:**
+- [ ] Skills mounted to `~/.claude/skills/`
+- [ ] Skill appears in agent's available skills
+- [ ] Skill can be invoked via query
+
+## Verification Script
+
+Quick verification for all steps:
+
+```bash
+#!/bin/bash
+set -e
+
+echo "=== Step 1: Hello World ==="
+kubectl get pods -l app.kubernetes.io/name=claude-code-agent
+kubectl get a2aserver
+kubectl get agent
+ark query agent/claude-code-agent "Say hello" | head -5
+
+echo "=== Step 2: OTEL ==="
+kubectl get configmap otel-environment-variables 2>/dev/null && echo "OTEL configured" || echo "No OTEL config"
+
+echo "=== Step 3: MCP ==="
+kubectl get secret mcp-config 2>/dev/null && echo "MCP configured" || echo "No MCP config"
+
+echo "=== Step 4: Skills ==="
+kubectl get configmap skills-config 2>/dev/null && echo "Skills configured" || echo "No skills config"
+
+echo "=== Done ==="
+```
+
+## Resources
+
+Installation resources are in `99-resources/`:
+- `step1-install.sh` - Basic helm install
+- `otel-configmap.yaml` - OTEL environment configuration
+- `mcp-config.yaml` - MCP server configuration
+- `skills-config.yaml` - Claude skills configuration
+
+## Expected Outcome
+
+After completing all steps:
+1. Claude Code agent running in cluster
+2. Queries execute via Ark API
+3. OTEL traces flow to backend
+4. MCP servers available for tool use
+5. Skills configured and invocable

--- a/tasks/001-claude-code-ark-integration/05-verification.md
+++ b/tasks/001-claude-code-ark-integration/05-verification.md
@@ -1,0 +1,68 @@
+# Verification
+
+Maps acceptance criteria to evidence.
+
+## Acceptance Criteria
+
+### Core Integration
+
+| Criterion | How to Verify | Status |
+|-----------|---------------|--------|
+| A2AServer shows Ready | `kubectl get a2aserver claude-code -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` returns "True" | pending |
+| Agent CRD auto-created | `kubectl get agent claude-code` succeeds | pending |
+| Agent has executionEngine: a2a | `kubectl get agent claude-code -o yaml` shows `spec.executionEngine: a2a` | pending |
+| Query returns response | `ark query agent/claude-code "Hello"` returns text | pending |
+
+### Observability
+
+| Criterion | How to Verify | Status |
+|-----------|---------------|--------|
+| OTEL traces emitted | Agent logs show span export or collector receives spans | pending |
+| Trace context propagated | Spans have parent trace ID from Ark request | pending |
+
+### Optional (Follow-on)
+
+| Criterion | How to Verify | Status |
+|-----------|---------------|--------|
+| OTEL visible in Ark Broker | `/v1/traces` API returns spans from claude-code-agent | deferred |
+| A2A artifacts capture logs | A2ATask `.status.artifacts` populated | deferred |
+
+## Evidence Collection
+
+### Deployment Evidence
+
+```bash
+# Capture deployment state
+kubectl get pods -l app=claude-code-agent -o yaml > evidence/pods.yaml
+kubectl get a2aserver claude-code -o yaml > evidence/a2aserver.yaml
+kubectl get agent claude-code -o yaml > evidence/agent.yaml
+```
+
+### Query Evidence
+
+```bash
+# Capture query response
+ark query agent/claude-code "What is 2+2?" > evidence/query-response.txt
+```
+
+### OTEL Evidence
+
+```bash
+# Capture agent logs showing telemetry
+kubectl logs -l app=claude-code-agent --tail=100 > evidence/agent-logs.txt
+```
+
+## Gaps
+
+- **Streaming**: A2A uses blocking mode; no intermediate text streaming
+- **Dashboard visibility**: Traces not yet visible in Ark Dashboard
+- **Multi-turn context**: Session management needs validation
+
+## Success Definition
+
+Integration is complete when:
+1. A2AServer and Agent CRDs are Ready
+2. Queries execute and return responses
+3. OTEL traces are emitted by claude-code-agent
+
+Follow-on work for enhanced visibility is documented in `99-findings/`.

--- a/tasks/001-claude-code-ark-integration/06-outcome.md
+++ b/tasks/001-claude-code-ark-integration/06-outcome.md
@@ -1,0 +1,98 @@
+# Outcome
+
+## Summary
+
+**Ark already has native A2A support.** Integration requires zero code changes to Ark.
+
+The initial analysis incorrectly assumed we needed to modify the execution engine or build new integration code. After examining Ark's architecture:
+
+1. **Ark has a native Go agentic loop** (`executeLocally`) as the default execution path
+2. **Execution engines are optional overrides** for external systems
+3. **`a2a` is a reserved execution engine name** with built-in support
+4. **A2AServer CRD + controller** handles discovery and agent creation automatically
+
+## Key Learnings
+
+1. **Ark's architecture is more sophisticated than initially understood** - The native Go loop handles most agent work; execution engines are for "swapping out" to external systems
+
+2. **A2A is first-class in Ark** - Full client implementation, auto-discovery, agent creation, OTEL header injection
+
+3. **Zero-code integration is possible** - Deploy claude-code-agent, create A2AServer CRD, done
+
+4. **OTEL flows through A2A** - Ark injects trace headers via `telemetry.InjectOTELHeaders()` in `a2a.go:188-192`
+
+## Decisions Made
+
+| Decision | Rationale |
+|----------|-----------|
+| Use existing A2A support | Zero code changes, already production-ready |
+| Don't modify executor-langchain | Wrong abstraction - that's for HTTP engines, not A2A |
+| Leverage Helm chart | claude-code-agent already has working Helm deployment |
+| Multiple deployments for multi-agent | Each Helm release = separate A2AServer = separate Agent |
+| Start with OTEL for visibility | Minimal change, works today |
+
+## Integration Steps
+
+```bash
+# 1. Deploy claude-code-agent with OTEL
+helm install claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --set apiKey=$ANTHROPIC_API_KEY \
+  --set env.CLAUDE_CODE_ENABLE_TELEMETRY=1
+
+# 2. Create A2AServer
+kubectl apply -f - <<EOF
+apiVersion: ark.mckinsey.com/v1prealpha1
+kind: A2AServer
+metadata:
+  name: claude-code
+spec:
+  address:
+    value: "http://claude-code-agent:2222"
+  timeout: "30m"
+EOF
+
+# 3. Verify discovery
+kubectl get a2aserver
+kubectl get agent
+
+# 4. Query
+ark query agent/claude-code "Hello"
+```
+
+## Follow-on Work
+
+### Immediate (Visibility Enhancements)
+
+| Task | Description |
+|------|-------------|
+| Configure OTEL export to Ark Broker | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://ark-broker:3000` to centralize traces |
+| Use A2A artifacts | Claude Code agent can update artifacts (e.g., logs) that Ark captures in A2ATask |
+
+### Future Enhancements
+
+| Task | Description |
+|------|-------------|
+| Multi-agent Helm values | Document configs for specialized agents (research, coding, etc.) |
+| Marketplace integration | Package as marketplace component |
+| Async A2A mode | Enable real-time status via A2ATask polling (requires Ark changes) |
+| SSE streaming | True real-time intermediate text (requires Ark A2A client changes) |
+
+## Known Limitations
+
+1. **No streaming currently** - A2A execution engine sends final response as single chunk
+2. **Blocking mode** - Ark's A2A client uses `Blocking: true` (see `a2a.go:143-153`)
+3. **Skills annotation** - Skills from agent card stored in annotation, not exposed in UI
+4. **Session management** - Context ID passed but multi-turn behavior unclear
+
+## Key Code References
+
+| Component | File | Line |
+|-----------|------|------|
+| A2A reserved constant | `ark/internal/genai/a2a_types.go` | 10 |
+| A2A routing decision | `ark/internal/genai/agent.go` | 79 |
+| A2A execution | `ark/internal/genai/a2a_execution.go` | 34-132 |
+| A2A blocking config | `ark/internal/genai/a2a.go` | 143-153 |
+| OTEL header injection | `ark/internal/genai/a2a.go` | 188-192 |
+| A2AServer controller | `ark/internal/controller/a2aserver_controller.go` | 51-367 |
+| A2ATask controller (polling) | `ark/internal/controller/a2atask_controller.go` | 37-98 |
+| claude-code-agent StatusUpdate | `src/claude-code-executor.ts` | 192-209 |

--- a/tasks/001-claude-code-ark-integration/99-findings/01-visibility-enhancements.md
+++ b/tasks/001-claude-code-ark-integration/99-findings/01-visibility-enhancements.md
@@ -1,0 +1,74 @@
+# Visibility Enhancements
+
+Side discovery from Claude Code Ark integration exploration.
+
+## Context
+
+During integration, we identified that OTEL traces are emitted by claude-code-agent but not yet visible in Ark's centralized observability.
+
+## Immediate Options
+
+### Option 1: Configure OTEL Export to Ark Broker
+
+Set environment variables to route telemetry to Ark Broker's OTLP endpoint.
+
+```yaml
+env:
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://ark-broker:3000"
+```
+
+**Pros:** Works today, shows tool/model calls
+**Cons:** Debugging-focused, not text streaming
+
+### Option 2: Use A2A Artifacts
+
+Claude Code agent can update artifacts during execution. Ark captures these in A2ATask status.
+
+```typescript
+// In claude-code-executor.ts, update artifact with logs
+await a2a.updateArtifact({
+  name: "execution-log",
+  mimeType: "text/plain",
+  data: logContent
+});
+```
+
+**Pros:** Richer visibility than traces alone
+**Cons:** Requires claude-code-agent changes
+
+## Future Options (Require Ark Changes)
+
+### Async A2A Mode + A2ATask Polling
+
+```
+Query -> A2A (Blocking: false) -> A2ATask created immediately
+                                      |
+                        A2ATaskReconciler polls every 5s
+                                      |
+                        status.history updated with messages
+```
+
+**Changes:** Set `Blocking: false`, create A2ATask before completion
+**Pros:** K8s-native, uses existing infrastructure
+**Cons:** 5s polling interval, not true streaming
+
+### SSE Streaming via tasks/sendSubscribe
+
+```
+Query -> A2A sendSubscribe (SSE) -> Real-time StatusUpdate events
+                                      |
+                        Ark forwards to EventStreamInterface
+```
+
+**Changes:** Implement `tasks/sendSubscribe` in Ark A2A client
+**Pros:** True real-time, shows tool calls and text
+**Cons:** More complex implementation
+
+## Recommendation
+
+Start with Option 1 (OTEL export). It provides basic visibility with zero code changes to either Ark or claude-code-agent, just Helm configuration.
+
+## Status
+
+Not blocking for initial integration. Can be pursued after core integration is verified.

--- a/tasks/001-claude-code-ark-integration/99-findings/02-otel-auto-injection.md
+++ b/tasks/001-claude-code-ark-integration/99-findings/02-otel-auto-injection.md
@@ -1,0 +1,89 @@
+# Finding: OTEL Auto-Injection Pattern
+
+## Summary
+
+Ark uses a standardized ConfigMap/Secret pattern for OTEL configuration. Services that include `envFrom` references to `otel-environment-variables` automatically pick up OTEL settings.
+
+## Current State
+
+| Component | Has Pattern? | Location |
+|-----------|--------------|----------|
+| ark-controller | ✅ Yes | `ark/dist/chart/templates/manager/manager.yaml:54-60` |
+| claude-code-agent | ❌ No | `chart/templates/deployment.yaml` |
+
+## Required Change
+
+Add `envFrom` to `claude-code-agent/chart/templates/deployment.yaml` after the `env` block (around line 52):
+
+```yaml
+          env:
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  # ... existing config
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          # ADD THIS BLOCK:
+          envFrom:
+          - configMapRef:
+              name: otel-environment-variables
+              optional: true
+          - secretRef:
+              name: otel-environment-variables
+              optional: true
+```
+
+## How It Works
+
+1. **If ConfigMap/Secret exists** → OTEL env vars injected automatically
+2. **If not** → Deployment works without OTEL (optional: true)
+3. **No Helm values needed** → Auto-discovery from namespace
+
+## Example ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-environment-variables
+  namespace: default  # Same namespace as claude-code-agent
+data:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-svc.phoenix:4317"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+  OTEL_SERVICE_NAME: "claude-code-agent"
+```
+
+## Example Secret (for auth headers)
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: otel-environment-variables
+  namespace: default
+type: Opaque
+stringData:
+  OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Bearer <token>"
+```
+
+## Benefits
+
+1. **Consistent with Ark** - Same pattern as ark-controller
+2. **Zero config** - Works automatically if OTEL is configured in namespace
+3. **Flexible** - Works with any OTEL backend (Phoenix, Langfuse, Jaeger, etc.)
+4. **Secure** - Sensitive headers can go in Secret
+
+## Documentation Reference
+
+From `docs/content/developer-guide/observability/index.mdx`:
+
+> One way to set up automatic OpenTelemetry configuration is through standardized ConfigMap and Secret references. This pattern allows any Kubernetes resource to automatically pick up OTEL environment variables when available.
+
+## Action Items
+
+- [x] Update claude-code-agent chart with `envFrom` pattern
+- [ ] Document in chart README
+- [ ] Release new chart version

--- a/tasks/001-claude-code-ark-integration/99-resources/README.md
+++ b/tasks/001-claude-code-ark-integration/99-resources/README.md
@@ -1,0 +1,56 @@
+# Resources
+
+Installation resources for each prototype step.
+
+## Prerequisites
+
+- Ark installed in cluster
+- `ANTHROPIC_API_KEY` environment variable set
+
+## Step 1: Hello World
+
+```bash
+./step1-install.sh
+```
+
+Or manually:
+```bash
+helm install claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY
+```
+
+## Step 2: OTEL
+
+```bash
+kubectl apply -f otel-configmap.yaml
+kubectl rollout restart deployment/claude-code-agent
+```
+
+## Step 3: MCP
+
+```bash
+kubectl apply -f mcp-config.yaml
+helm upgrade claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY \
+  --set mcpConfig.existingSecret=mcp-config
+```
+
+## Step 4: Skills
+
+```bash
+kubectl apply -f skills-config.yaml
+helm upgrade claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY \
+  --set skills.existingConfigMap=skills-config
+```
+
+## Uninstall
+
+```bash
+helm uninstall claude-code-agent
+kubectl delete configmap otel-environment-variables skills-config 2>/dev/null || true
+kubectl delete secret mcp-config 2>/dev/null || true
+```

--- a/tasks/001-claude-code-ark-integration/99-resources/mcp-config.yaml
+++ b/tasks/001-claude-code-ark-integration/99-resources/mcp-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-config
+type: Opaque
+stringData:
+  mcp.json: |
+    {
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@anthropic-ai/filesystem-mcp", "/tmp"]
+        }
+      }
+    }

--- a/tasks/001-claude-code-ark-integration/99-resources/otel-configmap.yaml
+++ b/tasks/001-claude-code-ark-integration/99-resources/otel-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-environment-variables
+data:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-svc.phoenix:4317"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"

--- a/tasks/001-claude-code-ark-integration/99-resources/otel.md
+++ b/tasks/001-claude-code-ark-integration/99-resources/otel.md
@@ -1,0 +1,236 @@
+# OpenTelemetry Integration for claude-code-agent
+
+## Problem Statement
+
+Claude Code CLI and Phoenix (Arize) use different OpenTelemetry signals, making them incompatible out of the box.
+
+### Claude Code CLI Telemetry
+
+Claude Code exports **metrics and logs**, not traces:
+
+- `OTEL_METRICS_EXPORTER` - token usage, cost, duration as time-series metrics
+- `OTEL_LOGS_EXPORTER` - events with session metadata
+
+From the [official docs](https://code.claude.com/docs/en/monitoring-usage):
+
+> "Claude Code supports OpenTelemetry (OTel) metrics and events for monitoring and observability. All metrics are time series data exported via OpenTelemetry's standard metrics protocol, and events are exported via OpenTelemetry's logs/events protocol."
+
+Example log output (from [GitHub #2090](https://github.com/anthropics/claude-code/issues/2090)):
+```json
+{
+  "cost_usd": "0.011956950000000001",
+  "duration_ms": "11145",
+  "input_tokens": "4",
+  "output_tokens": "225",
+  "model": "claude-sonnet-4-20250514",
+  "session.id": "...",
+  "user.id": "..."
+}
+```
+
+### Phoenix (Arize) Telemetry
+
+Phoenix only accepts **traces** (spans):
+
+- Endpoint: `/v1/traces`
+- No support for `/v1/metrics` or `/v1/logs`
+- Built around OpenTelemetry TracerProvider, SpanProcessor, SpanExporter
+
+From [Phoenix OTEL docs](https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel):
+
+> "The phoenix.otel module provides drop-in replacements for OpenTelemetry TracerProvider, SimpleSpanProcessor, BatchSpanProcessor, HTTPSpanExporter, and GRPCSpanExporter."
+
+### The Gap
+
+| Signal | Claude Code CLI | Phoenix |
+|--------|-----------------|---------|
+| Traces | ❌ Not exported | ✅ Supported |
+| Metrics | ✅ Exported | ❌ Not supported |
+| Logs | ✅ Exported | ❌ Not supported |
+
+## Solution: Add Tracing to claude-code-agent
+
+The `claude-code-agent` is a Node.js wrapper that exposes Claude Code as an A2A server. We can add OpenTelemetry tracing at this layer to capture:
+
+- Request/response lifecycle as spans
+- Duration of Claude Code execution
+- Token counts and costs (parsed from output)
+- Error states
+- A2A message metadata
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     claude-code-agent                        │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              OpenTelemetry Tracing                   │    │
+│  │  - Start span on A2A request                        │    │
+│  │  - Add attributes (message.id, context.id, model)   │    │
+│  │  - End span on response complete                    │    │
+│  │  - Export to Phoenix via OTLP/HTTP                  │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                            │                                 │
+│                            ▼                                 │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              Claude Code CLI                         │    │
+│  │  - Executes prompts                                 │    │
+│  │  - Exports metrics/logs (separate from traces)      │    │
+│  └─────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ OTLP/HTTP traces
+┌─────────────────────────────────────────────────────────────┐
+│                        Phoenix                               │
+│  - Receives traces from claude-code-agent                   │
+│  - Visualizes LLM call spans                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Implementation
+
+#### 1. Dependencies
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-node \
+  @opentelemetry/exporter-trace-otlp-http \
+  @opentelemetry/semantic-conventions
+```
+
+#### 2. Initialize Tracing (src/tracing.ts)
+
+```typescript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+
+export function initTracing() {
+  const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (!endpoint || process.env.CLAUDE_CODE_ENABLE_TELEMETRY !== '1') {
+    console.log('Tracing disabled (OTEL_EXPORTER_OTLP_ENDPOINT not set or telemetry disabled)');
+    return;
+  }
+
+  const sdk = new NodeSDK({
+    resource: new Resource({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || 'claude-code-agent',
+    }),
+    traceExporter: new OTLPTraceExporter({
+      url: `${endpoint}/v1/traces`,
+    }),
+  });
+
+  sdk.start();
+  console.log(`Tracing enabled, exporting to ${endpoint}/v1/traces`);
+
+  process.on('SIGTERM', () => sdk.shutdown());
+}
+```
+
+#### 3. Instrument A2A Handler
+
+```typescript
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('claude-code-agent');
+
+async function handleMessage(message: A2AMessage): Promise<A2AResponse> {
+  const span = tracer.startSpan('claude-code.query', {
+    attributes: {
+      'message.id': message.messageId,
+      'context.id': message.contextId,
+      'message.role': message.role,
+    },
+  });
+
+  try {
+    const startTime = Date.now();
+    const result = await executeClaudeCode(message);
+    const duration = Date.now() - startTime;
+
+    span.setAttributes({
+      'llm.duration_ms': duration,
+      'llm.model': result.model || 'unknown',
+      'llm.input_tokens': result.inputTokens || 0,
+      'llm.output_tokens': result.outputTokens || 0,
+    });
+
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+
+  } catch (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error.message,
+    });
+    span.recordException(error);
+    throw error;
+
+  } finally {
+    span.end();
+  }
+}
+```
+
+#### 4. Initialize at Startup (src/main.ts)
+
+```typescript
+import { initTracing } from './tracing';
+
+// Initialize tracing before anything else
+initTracing();
+
+// ... rest of main.ts
+```
+
+### Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable tracing (required) | `1` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Phoenix endpoint | `http://phoenix-svc.phoenix:6006` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol (http/protobuf recommended) | `http/protobuf` |
+| `OTEL_SERVICE_NAME` | Service name in traces | `claude-code-agent` |
+
+### Helm Values Example
+
+```yaml
+env:
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+  OTEL_SERVICE_NAME: "claude-code-agent"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-svc.phoenix.svc.cluster.local:6006"
+```
+
+### Span Attributes
+
+Recommended attributes to capture:
+
+| Attribute | Description |
+|-----------|-------------|
+| `message.id` | A2A message ID |
+| `context.id` | A2A context/conversation ID |
+| `message.role` | user/assistant |
+| `llm.model` | Model used (e.g., claude-sonnet-4) |
+| `llm.input_tokens` | Input token count |
+| `llm.output_tokens` | Output token count |
+| `llm.duration_ms` | Execution time |
+| `llm.cost_usd` | Cost if available |
+
+### Expected Result
+
+After implementation, Phoenix will show:
+
+- One trace per A2A query
+- Span duration showing Claude Code execution time
+- Attributes with token counts, model, message IDs
+- Error traces for failed queries
+
+## References
+
+- [Claude Code Monitoring Docs](https://code.claude.com/docs/en/monitoring-usage)
+- [Phoenix OTEL Setup](https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel)
+- [OpenTelemetry JS SDK](https://opentelemetry.io/docs/languages/js/)
+- [GitHub Issue #2090](https://github.com/anthropics/claude-code/issues/2090) - Claude Code telemetry limitations
+- [GitHub Issue #1712](https://github.com/anthropics/claude-code/issues/1712) - OTEL configuration

--- a/tasks/001-claude-code-ark-integration/99-resources/skills-config.yaml
+++ b/tasks/001-claude-code-ark-integration/99-resources/skills-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skills-config
+data:
+  greeting-SKILL.md: |
+    # Greeting Skill
+
+    When asked to greet someone, respond with a friendly greeting that includes:
+    - A warm welcome message
+    - The current context (Ark cluster)
+    - An offer to help with tasks

--- a/tasks/001-claude-code-ark-integration/99-resources/step1-install.sh
+++ b/tasks/001-claude-code-ark-integration/99-resources/step1-install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  echo "Error: ANTHROPIC_API_KEY not set"
+  exit 1
+fi
+
+echo "=== Step 1: Install claude-code-agent ==="
+
+helm install claude-code-agent oci://ghcr.io/dwmkerr/charts/claude-code-agent \
+  --version ">=0.1.3" \
+  --set apiKey=$ANTHROPIC_API_KEY
+
+echo "=== Waiting for pod ==="
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=claude-code-agent --timeout=120s
+
+echo "=== Verify A2AServer ==="
+kubectl get a2aserver
+
+echo "=== Verify Agent ==="
+kubectl get agent
+
+echo "=== Test query ==="
+ark query agent/claude-code-agent "What is 2 + 2?"
+
+echo "=== Step 1 complete ==="


### PR DESCRIPTION
## Summary
- Exploration task for integrating Claude Code with Ark via A2A protocol
- Documented OTEL signal mismatch: Claude Code exports metrics/logs, Phoenix needs traces
- Created implementation plan for adding tracing to claude-code-agent wrapper

## Key Findings
- Claude Code A2A agent deploys successfully via Helm
- A2AServer and Agent CRDs auto-created by Ark
- OTEL integration blocked due to signal type mismatch (see `99-resources/otel.md`)

## Related PRs
- dwmkerr/claude-code-agent#16 - OTEL docs
- mckinsey/agents-at-scale-marketplace#89 - Phoenix protocol fix