### PR TITLE
feat(ark-cli): add 'ark okf export' - export cluster as OKF knowledge bundle (spike)

### DIFF
--- a/tools/ark-cli/src/commands/okf/index.spec.ts
+++ b/tools/ark-cli/src/commands/okf/index.spec.ts
@@ -1,0 +1,151 @@
+import {vi} from 'vitest';
+import {Command} from 'commander';
+
+const mockExeca = vi.fn() as any;
+vi.mock('execa', () => ({
+  execa: mockExeca,
+}));
+
+const mockWriteFile = vi.fn() as any;
+const mockMkdir = vi.fn() as any;
+vi.mock('fs/promises', () => ({
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+}));
+
+const mockOutput = {
+  info: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+};
+vi.mock('../../lib/output.js', () => ({
+  default: mockOutput,
+}));
+
+const {createOkfCommand} = await import('./index.js');
+import type {ArkConfig} from '../../lib/config.js';
+
+function kubectlList(items: unknown[]) {
+  return {
+    stdout: JSON.stringify({
+      apiVersion: 'v1',
+      kind: 'List',
+      items,
+      metadata: {resourceVersion: ''},
+    }),
+  };
+}
+
+const agent = {
+  metadata: {
+    name: 'researcher',
+    namespace: 'default',
+    creationTimestamp: '2026-07-01T00:00:00Z',
+  },
+  spec: {
+    description: 'Researches topics.',
+    prompt: 'You are a researcher.',
+    modelRef: {name: 'gpt4'},
+    tools: [{type: 'mcp', name: 'github-search'}],
+  },
+};
+
+const model = {
+  metadata: {name: 'gpt4', namespace: 'default'},
+  spec: {type: 'openai', model: {value: 'gpt-4o'}},
+};
+
+const team = {
+  metadata: {name: 'crew', namespace: 'default'},
+  spec: {
+    strategy: 'sequential',
+    members: [{name: 'researcher', type: 'agent'}],
+  },
+};
+
+const mcpServer = {
+  metadata: {name: 'github', namespace: 'default'},
+  spec: {transport: 'http', description: 'GitHub MCP server.'},
+  status: {resolvedAddress: 'http://github-mcp.default.svc/mcp'},
+};
+
+const tool = {
+  metadata: {name: 'github-search', namespace: 'default'},
+  spec: {mcp: {mcpServerRef: {name: 'github'}, toolName: 'search'}},
+};
+
+describe('okf command', () => {
+  const mockConfig: ArkConfig = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create okf command with export subcommand', () => {
+    const command = createOkfCommand(mockConfig);
+
+    expect(command).toBeInstanceOf(Command);
+    expect(command.name()).toBe('okf');
+    expect(command.commands.map((c) => c.name())).toContain('export');
+  });
+
+  it('should export cluster resources as an OKF bundle', async () => {
+    // listResources is called once per resource type, in Promise.all order:
+    // agents, models, teams, mcpservers, tools.
+    mockExeca
+      .mockResolvedValueOnce(kubectlList([agent]))
+      .mockResolvedValueOnce(kubectlList([model]))
+      .mockResolvedValueOnce(kubectlList([team]))
+      .mockResolvedValueOnce(kubectlList([mcpServer]))
+      .mockResolvedValueOnce(kubectlList([tool]));
+    mockWriteFile.mockResolvedValue(undefined);
+    mockMkdir.mockResolvedValue(undefined);
+
+    const command = createOkfCommand(mockConfig);
+    await command.parseAsync(['node', 'ark', 'export', '-o', '/tmp/bundle']);
+
+    const written = new Map<string, string>(
+      mockWriteFile.mock.calls.map((call: string[]) => [call[0], call[1]])
+    );
+
+    expect([...written.keys()].sort()).toEqual([
+      '/tmp/bundle/agents/researcher.md',
+      '/tmp/bundle/index.md',
+      '/tmp/bundle/log.md',
+      '/tmp/bundle/mcpservers/github.md',
+      '/tmp/bundle/models/gpt4.md',
+      '/tmp/bundle/teams/crew.md',
+    ]);
+
+    const agentDoc = written.get('/tmp/bundle/agents/researcher.md')!;
+    expect(agentDoc).toContain('type: Ark Agent');
+    expect(agentDoc).toContain('description: Researches topics.');
+    expect(agentDoc).toContain('[gpt4](../models/gpt4.md)');
+    expect(agentDoc).toContain('[github](../mcpservers/github.md)');
+
+    const indexDoc = written.get('/tmp/bundle/index.md')!;
+    expect(indexDoc).toContain('okf_version: "0.1"');
+    expect(indexDoc).toContain('[researcher](agents/researcher.md)');
+
+    const serverDoc = written.get('/tmp/bundle/mcpservers/github.md')!;
+    expect(serverDoc).toContain('type: Ark MCP Server');
+    expect(serverDoc).toContain('github-search');
+
+    expect(mockOutput.success).toHaveBeenCalledWith(
+      expect.stringContaining('exported 4 concepts')
+    );
+  });
+
+  it('should warn when no resources are found', async () => {
+    mockExeca.mockResolvedValue(kubectlList([]));
+
+    const command = createOkfCommand(mockConfig);
+    await command.parseAsync(['node', 'ark', 'export']);
+
+    expect(mockOutput.warning).toHaveBeenCalledWith(
+      'no resources found to export'
+    );
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/tools/ark-cli/src/commands/okf/index.ts
+++ b/tools/ark-cli/src/commands/okf/index.ts
@@ -1,0 +1,290 @@
+import {Command} from 'commander';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import yaml from 'yaml';
+import type {ArkConfig} from '../../lib/config.js';
+import {listResources} from '../../lib/kubectl.js';
+import output from '../../lib/output.js';
+
+// Minimal shapes for the fields we project into OKF - we deliberately don't
+// depend on generated types so the exporter degrades gracefully as CRDs evolve.
+interface ArkResource {
+  metadata: {
+    name: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    labels?: Record<string, string>;
+  };
+  spec?: Record<string, unknown>;
+  status?: Record<string, unknown>;
+}
+
+interface OkfExportOptions {
+  output: string;
+  namespace?: string;
+}
+
+interface Concept {
+  // Bundle-relative path without the .md suffix, e.g. "agents/researcher".
+  id: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+const OKF_VERSION = '0.1';
+
+function conceptDocument(concept: Concept): string {
+  // Frontmatter is emitted via the yaml library so values with quotes,
+  // colons or newlines stay parseable - a spec conformance requirement.
+  const frontmatter = yaml.stringify(concept.frontmatter).trimEnd();
+  return `---\n${frontmatter}\n---\n\n${concept.body.trimEnd()}\n`;
+}
+
+function baseFrontmatter(
+  type: string,
+  resource: ArkResource,
+  tags: string[]
+): Record<string, unknown> {
+  const frontmatter: Record<string, unknown> = {
+    type,
+    title: resource.metadata.name,
+  };
+  const description = resource.spec?.description;
+  if (typeof description === 'string' && description) {
+    frontmatter.description = description;
+  }
+  // The OKF `resource` field wants a canonical URI for the underlying asset;
+  // a k8s-style URI keeps it unambiguous without pointing at any one dashboard.
+  frontmatter.resource = `k8s://ark.mckinsey.com/v1alpha1/namespaces/${
+    resource.metadata.namespace || 'default'
+  }/${type.toLowerCase().replace(/^ark /, '').replace(/ /g, '')}s/${
+    resource.metadata.name
+  }`;
+  frontmatter.tags = tags.concat(resource.metadata.namespace || 'default');
+  if (resource.metadata.creationTimestamp) {
+    frontmatter.timestamp = resource.metadata.creationTimestamp;
+  }
+  return frontmatter;
+}
+
+function modelConcept(model: ArkResource): Concept {
+  const spec = model.spec || {};
+  const modelValue = (spec.model as {value?: string} | undefined)?.value;
+  const lines = [
+    `Provider type: \`${spec.type || 'unknown'}\`.`,
+    modelValue ? `Underlying model: \`${modelValue}\`.` : '',
+  ].filter(Boolean);
+  return {
+    id: `models/${model.metadata.name}`,
+    frontmatter: baseFrontmatter('Ark Model', model, ['model']),
+    body: lines.join('\n'),
+  };
+}
+
+function agentConcept(
+  agent: ArkResource,
+  toolToMcpServer: Map<string, string>
+): Concept {
+  const spec = agent.spec || {};
+  const sections: string[] = [];
+
+  const modelRef = spec.modelRef as {name?: string} | undefined;
+  // Every reference becomes a markdown link so the bundle forms the
+  // agent -> model -> mcp-server graph OKF consumers can traverse. Links are
+  // relative rather than bundle-absolute: the spec allows both but Google's
+  // reference visualizer only follows relative links.
+  sections.push(
+    `Uses model [${modelRef?.name || 'default'}](../models/${
+      modelRef?.name || 'default'
+    }.md).`
+  );
+
+  const tools = (spec.tools as {type?: string; name?: string}[]) || [];
+  if (tools.length > 0) {
+    const toolLines = tools.map((tool) => {
+      const serverName = tool.name ? toolToMcpServer.get(tool.name) : undefined;
+      const suffix = serverName
+        ? ` (served by [${serverName}](../mcpservers/${serverName}.md))`
+        : '';
+      return `* \`${tool.name}\` - ${tool.type} tool${suffix}`;
+    });
+    sections.push(`# Tools\n\n${toolLines.join('\n')}`);
+  }
+
+  if (typeof spec.prompt === 'string' && spec.prompt) {
+    sections.push(`# Prompt\n\n\`\`\`\n${spec.prompt.trim()}\n\`\`\``);
+  }
+
+  return {
+    id: `agents/${agent.metadata.name}`,
+    frontmatter: baseFrontmatter('Ark Agent', agent, ['agent']),
+    body: sections.join('\n\n'),
+  };
+}
+
+function teamConcept(team: ArkResource): Concept {
+  const spec = team.spec || {};
+  const members = (spec.members as {name?: string; type?: string}[]) || [];
+  const memberLines = members.map((member) => {
+    const dir = member.type === 'team' ? '.' : '../agents';
+    return `* [${member.name}](${dir}/${member.name}.md) (${member.type})`;
+  });
+  const sections = [
+    `Strategy: \`${spec.strategy || 'unknown'}\`.`,
+    `# Members\n\n${memberLines.join('\n')}`,
+  ];
+  return {
+    id: `teams/${team.metadata.name}`,
+    frontmatter: baseFrontmatter('Ark Team', team, ['team']),
+    body: sections.join('\n\n'),
+  };
+}
+
+function mcpServerConcept(server: ArkResource, toolNames: string[]): Concept {
+  const spec = server.spec || {};
+  const status = server.status || {};
+  // Address only - headers may reference secrets so they are never exported.
+  const address =
+    (status.resolvedAddress as string | undefined) ||
+    (spec.address as {value?: string} | undefined)?.value ||
+    'unresolved';
+  const sections = [
+    `Transport: \`${spec.transport || 'http'}\`. Address: \`${address}\`.`,
+  ];
+  if (toolNames.length > 0) {
+    const toolLines = toolNames.map((name) => `* \`${name}\``);
+    sections.push(`# Tools\n\n${toolLines.join('\n')}`);
+  }
+  return {
+    id: `mcpservers/${server.metadata.name}`,
+    frontmatter: baseFrontmatter('Ark MCP Server', server, ['mcp']),
+    body: sections.join('\n\n'),
+  };
+}
+
+function indexDocument(concepts: Concept[]): string {
+  const sections = new Map<string, string[]>();
+  for (const concept of concepts) {
+    const group = path.dirname(concept.id);
+    const entries = sections.get(group) || [];
+    const description =
+      (concept.frontmatter.description as string | undefined) ||
+      (concept.frontmatter.type as string);
+    entries.push(
+      `* [${concept.frontmatter.title}](${concept.id}.md) - ${description}`
+    );
+    sections.set(group, entries);
+  }
+  const titles: Record<string, string> = {
+    agents: 'Agents',
+    models: 'Models',
+    teams: 'Teams',
+    mcpservers: 'MCP Servers',
+  };
+  // Root index.md is the one place frontmatter is allowed to declare the
+  // bundle's OKF version (spec section 11).
+  const parts = [`---\nokf_version: "${OKF_VERSION}"\n---`];
+  for (const [group, entries] of sections) {
+    parts.push(`# ${titles[group] || group}\n\n${entries.join('\n')}`);
+  }
+  return `${parts.join('\n\n')}\n`;
+}
+
+function logDocument(conceptCount: number): string {
+  const today = new Date().toISOString().slice(0, 10);
+  return [
+    '# Directory Update Log',
+    '',
+    `## ${today}`,
+    `* **Initialization**: Exported ${conceptCount} concepts from the Ark cluster via \`ark okf export\`.`,
+    '',
+  ].join('\n');
+}
+
+async function exportOkfBundle(options: OkfExportOptions) {
+  try {
+    output.info(`exporting ark resources as an OKF bundle to ${options.output}...`);
+
+    const listOptions = {namespace: options.namespace};
+    const [agents, models, teams, mcpServers, tools] = await Promise.all([
+      listResources<ArkResource>('agents', listOptions),
+      listResources<ArkResource>('models', listOptions),
+      listResources<ArkResource>('teams', listOptions),
+      listResources<ArkResource>('mcpservers', listOptions),
+      listResources<ArkResource>('tools', listOptions),
+    ]);
+
+    // Agents reference MCP tools by Tool CR name; resolve each back to its
+    // server so agent documents can link agents -> mcpservers directly.
+    const toolToMcpServer = new Map<string, string>();
+    const mcpServerTools = new Map<string, string[]>();
+    for (const tool of tools) {
+      const mcpRef = tool.spec?.mcp as
+        | {mcpServerRef?: {name?: string}; toolName?: string}
+        | undefined;
+      const serverName = mcpRef?.mcpServerRef?.name;
+      if (!serverName) continue;
+      toolToMcpServer.set(tool.metadata.name, serverName);
+      const names = mcpServerTools.get(serverName) || [];
+      names.push(tool.metadata.name);
+      mcpServerTools.set(serverName, names);
+    }
+
+    const concepts: Concept[] = [
+      ...models.map(modelConcept),
+      ...agents.map((agent) => agentConcept(agent, toolToMcpServer)),
+      ...teams.map(teamConcept),
+      ...mcpServers.map((server) =>
+        mcpServerConcept(server, mcpServerTools.get(server.metadata.name) || [])
+      ),
+    ];
+
+    if (concepts.length === 0) {
+      output.warning('no resources found to export');
+      return;
+    }
+
+    for (const concept of concepts) {
+      const filePath = path.join(options.output, `${concept.id}.md`);
+      await fs.mkdir(path.dirname(filePath), {recursive: true});
+      await fs.writeFile(filePath, conceptDocument(concept), 'utf-8');
+    }
+    await fs.writeFile(
+      path.join(options.output, 'index.md'),
+      indexDocument(concepts),
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(options.output, 'log.md'),
+      logDocument(concepts.length),
+      'utf-8'
+    );
+
+    output.success(
+      `exported ${concepts.length} concepts to OKF bundle at ${options.output}`
+    );
+  } catch (error) {
+    output.error(
+      'okf export failed:',
+      error instanceof Error ? error.message : error
+    );
+  }
+}
+
+export function createOkfCommand(_config: ArkConfig): Command {
+  const okfCommand = new Command('okf');
+  okfCommand.description(
+    'work with Open Knowledge Format (OKF) bundles - https://github.com/GoogleCloudPlatform/knowledge-catalog'
+  );
+
+  okfCommand
+    .command('export')
+    .description('export ARK resources as an OKF knowledge bundle')
+    .option('-o, --output <dir>', 'output bundle directory', './ark-okf-bundle')
+    .option('-n, --namespace <namespace>', 'namespace to export from')
+    .action(async (options: OkfExportOptions) => {
+      await exportOkfBundle(options);
+    });
+
+  return okfCommand;
+}

--- a/tools/ark-cli/src/index.tsx
+++ b/tools/ark-cli/src/index.tsx
@@ -24,6 +24,7 @@ import {createMarketplaceCommand} from './commands/marketplace/index.js';
 import {createMcpCommand} from './commands/mcp/index.js';
 import {createMemoryCommand} from './commands/memory/index.js';
 import {createModelsCommand} from './commands/models/index.js';
+import {createOkfCommand} from './commands/okf/index.js';
 import {createQueryCommand} from './commands/query/index.js';
 import {createQueriesCommand} from './commands/queries/index.js';
 import {createUninstallCommand} from './commands/uninstall/index.js';
@@ -68,6 +69,7 @@ async function main() {
   program.addCommand(createMcpCommand(config));
   program.addCommand(createMemoryCommand(config));
   program.addCommand(createModelsCommand(config));
+  program.addCommand(createOkfCommand(config));
   program.addCommand(createQueryCommand(config));
   program.addCommand(createQueriesCommand(config));
   program.addCommand(createUninstallCommand(config));


### PR DESCRIPTION
## Summary
- Spike: exports the Ark cluster (Agents, Models, Teams, MCPServers) as a [Google Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) knowledge bundle - a directory of markdown concepts with YAML frontmatter, cross-linked into a knowledge graph.
- New `ark okf export` command in ark-cli; resource references (`modelRef`, MCP tools via Tool CRs, team members) become markdown links, so the bundle carries the agent → model → tool → MCP-server graph.
- No secrets exported: header values and API keys are never written; MCP servers only expose transport + resolved address.

## Why OKF
OKF is knowledge-as-data (inert, diffable files); MCP is tools-as-protocol (live capabilities). Ark already serves live cluster state over MCP via ark-mcp - this adds the complementary surface: a snapshot any agent or human can read with no kubectl, no MCP client, no cluster access. Same truth, two consumption models.

## Demo

Export the cluster as a bundle:

![ark okf export](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/ark-okf-export.gif)

An agent as an OKF concept - note the relative links forming the graph:

![agent concept](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/04-agent-concept.png)

Claude Code answering questions about the cluster **from the bundle files alone** (offline, no cluster access):

[![claude reads okf](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/claude-live-okf.gif)

The bundle also renders in Google's reference visualizer (`viz.html`, force-directed concept graph) with zero changes:

<img width="1468" height="712" alt="image" src="https://github.com/user-attachments/assets/638acdf7-43b4-4186-9f7f-eecbc9c83334" />





## Notes
- Links are relative rather than the spec-recommended `/`-rooted form: Google's own reference visualizer ignores `/`-rooted links, and relative links are equally spec-legal (§5.2) and portable.
- `npm test` and targeted `eslint` pass; the 4 eslint errors in `ark-cli` are pre-existing on `main` in files this PR does not touch.
- Spike scope deliberately small: no CRD changes, no controller changes. Obvious follow-ons: `okf serve` (bundle over MCP resources), CronJob export to git for a reviewable cluster-knowledge changelog.
